### PR TITLE
Add config.yaml parser to full_pipeline_server

### DIFF
--- a/full_pipeline_server.py
+++ b/full_pipeline_server.py
@@ -3,6 +3,7 @@ import os
 import flask
 
 from pipeline import Pipeline
+from full_pipeline_stream import read_pipelines
 
 app=flask.Flask(__name__)
 
@@ -35,8 +36,7 @@ argparser.add_argument('--pipeline', default="fi_tdt_all", help='Name of the pip
 argparser.add_argument('ACTION', default=None, nargs="?", help='`serve` to open http server, `interactive` goes interactive mode. Default: do nothing and exit')
 args = argparser.parse_args()
 
-with open(args.conf_yaml) as f:
-    pipelines=yaml.load(f)
+pipelines = read_pipelines(args.conf_yaml)
 
 p=Pipeline(steps=pipelines[args.pipeline])
 


### PR DESCRIPTION
#### Before
The full_pipeline_server does not handle the {thisdir} variable with models downloaded from http://bionlp-www.utu.fi/dep-parser-models/

#### After
The {thisdir} variable is expanded using the read_pipelines function from full_pipeline_stream.