### PR TITLE
Update Parser, account for package name change

### DIFF
--- a/parser_lib.py
+++ b/parser_lib.py
@@ -27,8 +27,8 @@ import sys
 import codecs
 from argparse import ArgumentParser
 
-from parser import Configurable
-from parser import Network
+from nparser import Configurable
+from nparser import Network
 import io
 import os
 

--- a/parser_mod.py
+++ b/parser_mod.py
@@ -6,7 +6,7 @@ import argparse
 import traceback
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "Parser-v2"))
-from parser.scripts.transfer_morpho import process_batch
+from nparser.scripts.transfer_morpho import process_batch
 
 def launch(args,q_in,q_out):
     try:


### PR DESCRIPTION
`parser` was renamed to `nparser`, as discussed in https://github.com/TurkuNLP/Turku-neural-parser-pipeline/issues/4