### PR TITLE
Explicit UTF-8 encoding for lemma cache

### DIFF
--- a/lemma_cache_mod.py
+++ b/lemma_cache_mod.py
@@ -43,7 +43,7 @@ class LemmaCacheWrapper():
 
     def read_cache(self, cache_file):
         """ make lemmatizer faster by keeping lemma cache (run lemmatizer only for words not in this cache) """
-        with open(cache_file, "rt") as f:
+        with open(cache_file, "rt", encoding="utf8") as f:
             for line in f:
                 form, upos, xpos, feats, lemma = line.strip().split("\t")
                 self.cache[(form, upos, xpos, feats)]=lemma


### PR DESCRIPTION
I ran into a new issue on Windows with the recent changes. Without explicating the encoding when reading the lemma cache, the pipeline will throw an error and never finish.

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 3852: cha
racter maps to <undefined>
```

Adding the explicit encoding avoids this issue.