### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6
+ARG MODEL=fi_tdt
+WORKDIR /app
+COPY requirements-*.txt ./
+RUN pip3 install --no-cache-dir -r requirements-cpu.txt
+COPY fetch_models.py ./
+RUN python3 fetch_models.py $MODEL
+COPY . .
+ENV MODEL ${MODEL}
+CMD python full_pipeline_stream.py --conf "models_${MODEL}/pipelines.yaml" parse_plaintext


### PR DESCRIPTION
Added Dockerfile that:

- installs all the dependencies
  -  _Hard coded CPU for now_
- downloads specified model
  - model can be changed with build argument
  -  defaults to fi_tdt
- starts `full_pipeline_stream.py`
  - default action hard coded to `parse_plaintext`

This image should be easily modifiable to needs of the user.

Note: This doesn't fetch required git submodules as the are expected to be cloned by the user beforehand.